### PR TITLE
Create ingredient list screen

### DIFF
--- a/app/src/main/java/com/example/kakelandet_mycookbook/Ingredient.kt
+++ b/app/src/main/java/com/example/kakelandet_mycookbook/Ingredient.kt
@@ -1,0 +1,4 @@
+package com.example.kakelandet_mycookbook
+
+class Ingredient {
+}

--- a/app/src/main/java/com/example/kakelandet_mycookbook/Ingredient.kt
+++ b/app/src/main/java/com/example/kakelandet_mycookbook/Ingredient.kt
@@ -1,4 +1,8 @@
 package com.example.kakelandet_mycookbook
 
-class Ingredient {
-}
+data class Ingredient(
+    val id: Long,
+    val title: String,
+    val quantity: Int,
+    val price: Int,
+)

--- a/app/src/main/java/com/example/kakelandet_mycookbook/IngredientListAdapter.kt
+++ b/app/src/main/java/com/example/kakelandet_mycookbook/IngredientListAdapter.kt
@@ -1,0 +1,4 @@
+package com.example.kakelandet_mycookbook
+
+class IngredientListAdapter {
+}

--- a/app/src/main/java/com/example/kakelandet_mycookbook/IngredientListAdapter.kt
+++ b/app/src/main/java/com/example/kakelandet_mycookbook/IngredientListAdapter.kt
@@ -1,4 +1,35 @@
 package com.example.kakelandet_mycookbook
 
-class IngredientListAdapter {
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.example.kakelandet_mycookbook.databinding.IngredientListItemBinding
+
+class IngredientListAdapter(
+    private var ingredientList: List<Ingredient>
+): RecyclerView.Adapter<IngredientListAdapter.IngredientListViewHolder>() {
+
+    inner class IngredientListViewHolder(val binding: IngredientListItemBinding) :
+        RecyclerView.ViewHolder(binding.root)
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): IngredientListViewHolder {
+        val binding = IngredientListItemBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+
+        return IngredientListViewHolder(binding)
+    }
+
+    override fun onBindViewHolder(holder: IngredientListViewHolder, position: Int) {
+        with(holder) {
+            with(ingredientList[position]) {
+                binding.ingredientTitle.text = this.title
+                binding.priceTextview.text = this.price.toString()
+                binding.quantityTextview.text = this.quantity.toString()
+            }
+        }
+    }
+
+    override fun getItemCount(): Int {
+        return ingredientList.size
+    }
+
 }

--- a/app/src/main/java/com/example/kakelandet_mycookbook/IngredientListViewModel.kt
+++ b/app/src/main/java/com/example/kakelandet_mycookbook/IngredientListViewModel.kt
@@ -1,4 +1,11 @@
 package com.example.kakelandet_mycookbook
 
-class IngredientListViewModel {
+import androidx.lifecycle.ViewModel
+
+class IngredientListViewModel: ViewModel() {
+    private val initiateIngredientList = ingredientList()
+
+    fun getIngredientList(): List<Ingredient> {
+        return initiateIngredientList
+    }
 }

--- a/app/src/main/java/com/example/kakelandet_mycookbook/IngredientListViewModel.kt
+++ b/app/src/main/java/com/example/kakelandet_mycookbook/IngredientListViewModel.kt
@@ -1,0 +1,4 @@
+package com.example.kakelandet_mycookbook
+
+class IngredientListViewModel {
+}

--- a/app/src/main/java/com/example/kakelandet_mycookbook/Ingredients.kt
+++ b/app/src/main/java/com/example/kakelandet_mycookbook/Ingredients.kt
@@ -1,0 +1,2 @@
+package com.example.kakelandet_mycookbook
+

--- a/app/src/main/java/com/example/kakelandet_mycookbook/Ingredients.kt
+++ b/app/src/main/java/com/example/kakelandet_mycookbook/Ingredients.kt
@@ -1,2 +1,72 @@
 package com.example.kakelandet_mycookbook
 
+fun ingredientList() : List<Ingredient> {
+    return listOf(
+        Ingredient(
+            id = 1,
+            title = "White Flour",
+            quantity = 1,
+            price = 10
+        ),
+        Ingredient(
+            id = 2,
+            title = "Sugar",
+            quantity = 1,
+            price = 10
+        ),
+        Ingredient(
+            id = 3,
+            title = "Milk",
+            quantity = 1,
+            price = 10
+        ),
+        Ingredient(
+            id = 4,
+            title = "Onions",
+            quantity = 1,
+            price = 10
+        ),
+        Ingredient(
+            id = 5,
+            title = "Cocoa powder",
+            quantity = 1,
+            price = 10
+        ),
+        Ingredient(
+            id = 6,
+            title = "Condensed Milk",
+            quantity = 1,
+            price = 10
+        ),
+        Ingredient(
+            id = 7,
+            title = "Butter",
+            quantity = 1,
+            price = 10
+        ),
+        Ingredient(
+            id = 8,
+            title = "Food coloring",
+            quantity = 1,
+            price = 10
+        ),
+        Ingredient(
+            id = 9,
+            title = "Olive oil",
+            quantity = 1,
+            price = 10
+        ),
+        Ingredient(
+            id = 10,
+            title = "Chicken",
+            quantity = 1,
+            price = 10
+        ),
+        Ingredient(
+            id = 11,
+            title = "Parmesan",
+            quantity = 1,
+            price = 10
+        ),
+    )
+}

--- a/app/src/main/java/com/example/kakelandet_mycookbook/IngredientsListFragment.kt
+++ b/app/src/main/java/com/example/kakelandet_mycookbook/IngredientsListFragment.kt
@@ -15,13 +15,6 @@ class IngredientsListFragment : Fragment() {
     private var _binding : FragmentIngredientsListBinding? = null
     private val binding get() = _binding!!
 
-    private lateinit var ingredientList: List<Ingredient>
-
-    override fun onCreate (savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        ingredientList = viewModel.getIngredientList()
-    }
-
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
@@ -30,7 +23,7 @@ class IngredientsListFragment : Fragment() {
         // Inflate the layout for this fragment
         _binding = FragmentIngredientsListBinding.inflate(inflater, container, false)
 
-        binding.ingredientsRv.adapter = IngredientListAdapter(ingredientList)
+        binding.ingredientsRv.adapter = IngredientListAdapter(viewModel.getIngredientList())
         binding.ingredientsRv.layoutManager = LinearLayoutManager(requireContext())
 
         return binding.root

--- a/app/src/main/java/com/example/kakelandet_mycookbook/IngredientsListFragment.kt
+++ b/app/src/main/java/com/example/kakelandet_mycookbook/IngredientsListFragment.kt
@@ -5,14 +5,34 @@ import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.fragment.app.viewModels
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.example.kakelandet_mycookbook.databinding.FragmentIngredientsListBinding
 
 class IngredientsListFragment : Fragment() {
+    private val viewModel: IngredientListViewModel by viewModels()
+
+    private var _binding : FragmentIngredientsListBinding? = null
+    private val binding get() = _binding!!
+
+    private lateinit var ingredientList: List<Ingredient>
+
+    override fun onCreate (savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        ingredientList = viewModel.getIngredientList()
+    }
 
     override fun onCreateView(
-        inflater: LayoutInflater, container: ViewGroup?,
+        inflater: LayoutInflater,
+        container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
         // Inflate the layout for this fragment
-        return inflater.inflate(R.layout.fragment_ingredients_list, container, false)
+        _binding = FragmentIngredientsListBinding.inflate(inflater, container, false)
+
+        binding.ingredientsRv.adapter = IngredientListAdapter(ingredientList)
+        binding.ingredientsRv.layoutManager = LinearLayoutManager(requireContext())
+
+        return binding.root
     }
 }

--- a/app/src/main/java/com/example/kakelandet_mycookbook/IngredientsListFragment.kt
+++ b/app/src/main/java/com/example/kakelandet_mycookbook/IngredientsListFragment.kt
@@ -35,4 +35,9 @@ class IngredientsListFragment : Fragment() {
 
         return binding.root
     }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
 }

--- a/app/src/main/java/com/example/kakelandet_mycookbook/RecipesListFragment.kt
+++ b/app/src/main/java/com/example/kakelandet_mycookbook/RecipesListFragment.kt
@@ -15,14 +15,6 @@ class RecipesListFragment : Fragment() {
     private var _binding: FragmentRecipesListBinding? = null
     private val binding get() = _binding!!
 
-    private lateinit var recipeList: List<Recipe>
-
-
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        recipeList = viewModel.getRecipesList()
-    }
-
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
@@ -30,7 +22,7 @@ class RecipesListFragment : Fragment() {
     ): View? {
         _binding = FragmentRecipesListBinding.inflate(inflater, container, false)
 
-        binding.recipesListRv.adapter = RecipeListAdapter(recipeList)
+        binding.recipesListRv.adapter = RecipeListAdapter(viewModel.getRecipesList())
         binding.recipesListRv.layoutManager = LinearLayoutManager(requireContext())
 
         return binding.root

--- a/app/src/main/res/layout/fragment_ingredients_list.xml
+++ b/app/src/main/res/layout/fragment_ingredients_list.xml
@@ -24,10 +24,8 @@
         android:layout_height="wrap_content"
         android:layout_marginEnd="16dp"
         android:layout_marginBottom="16dp"
-        android:clickable="true"
         app:srcCompat="@drawable/ic_add"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        android:focusable="true"
         android:contentDescription="@string/add_ingredient_button_description" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_ingredients_list.xml
+++ b/app/src/main/res/layout/fragment_ingredients_list.xml
@@ -25,7 +25,7 @@
         android:layout_marginEnd="16dp"
         android:layout_marginBottom="16dp"
         android:clickable="true"
-        android:src="@drawable/ic_add"
+        app:srcCompat="@drawable/ic_add"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         android:focusable="true"

--- a/app/src/main/res/layout/fragment_ingredients_list.xml
+++ b/app/src/main/res/layout/fragment_ingredients_list.xml
@@ -1,13 +1,33 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context=".IngredientsListFragment">
 
-    <TextView
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:text="@string/ingredients_list" />
 
-</FrameLayout>
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/ingredientsRv"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:listitem="@layout/ingredient_list_item"/>
+
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+        android:id="@+id/add_ingredient_fab"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="16dp"
+        android:layout_marginBottom="16dp"
+        android:clickable="true"
+        android:src="@drawable/ic_add"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:focusable="true"
+        android:contentDescription="@string/add_ingredient_button_description" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_recipes_list.xml
+++ b/app/src/main/res/layout/fragment_recipes_list.xml
@@ -20,7 +20,7 @@
             tools:listitem="@layout/recipes_list_item"/>
 
         <com.google.android.material.floatingactionbutton.FloatingActionButton
-            android:id="@+id/floatingActionButton"
+            android:id="@+id/add_recipe_fab"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginEnd="16dp"

--- a/app/src/main/res/layout/ingredient_list_item.xml
+++ b/app/src/main/res/layout/ingredient_list_item.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/ingredient_list_item.xml
+++ b/app/src/main/res/layout/ingredient_list_item.xml
@@ -1,6 +1,55 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent">
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+    <com.google.android.material.card.MaterialCardView
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:strokeWidth="1dp"
+        app:strokeColor="@color/kakelandet_brown"
+        app:cardCornerRadius="10dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" >
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+
+            <TextView
+                android:id="@+id/ingredient_title"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                style="@style/CardTitle"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="16dp"
+                android:layout_marginEnd="16dp"
+                android:text="Dummy Ingredient Name"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <TextView
+                android:id="@+id/quantity_textview"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="16dp"
+                android:layout_marginBottom="8dp"
+                android:text="1kg"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/ingredient_title" />
+
+            <TextView
+                android:id="@+id/price_textview"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="32dp"
+                android:text="$10"
+                app:layout_constraintBottom_toBottomOf="@+id/quantity_textview"
+                app:layout_constraintStart_toEndOf="@+id/quantity_textview"
+                app:layout_constraintTop_toTopOf="@+id/quantity_textview" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,4 +10,5 @@
     <string name="nav_open">Open</string>
     <string name="nav_close">Close</string>
     <string name="recipe_imageView_description">A picture of the recipe</string>
+    <string name="add_ingredient_button_description">Add Ingredient Button</string>
 </resources>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

### Please make sure to merge #14  first :D 

Closes: #8 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR introduces the files and code to add a RecyclerView for the Recipe List app.

Please note:

For now, the screen can be accessed using the navigation drawer at the top left corner (not by clicking on the Ingredients button on the home screen)

The RecyclerView is using a temporary file with dummy content (Ingredients.kt) just for visual aid.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Run the app
click on the Navigation Drawer
Click on the Ingredients menu item
make sure the dummy content is loaded and the list is scrollable

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

<img src="https://user-images.githubusercontent.com/30724184/208201778-b52e1b86-a0f1-46c7-898a-be691cd491a3.gif" width="350"/> 

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
