### PR TITLE
Add ingredient view

### DIFF
--- a/app/src/main/java/com/example/kakelandet_mycookbook/AddIngredientFragment.kt
+++ b/app/src/main/java/com/example/kakelandet_mycookbook/AddIngredientFragment.kt
@@ -1,0 +1,36 @@
+package com.example.kakelandet_mycookbook
+
+import android.os.Bundle
+import androidx.fragment.app.Fragment
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.viewModels
+import com.example.kakelandet_mycookbook.databinding.FragmentAddIngredientBinding
+
+
+class AddIngredientFragment : Fragment() {
+    private val viewModel: AddIngredientViewModel by viewModels()
+
+    private var _binding : FragmentAddIngredientBinding? = null
+    private val binding get() = _binding!!
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        _binding = FragmentAddIngredientBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        binding.addIngredientLabel.text = getString(R.string.ingredient_name_label)
+        binding.editTextIngredientName
+        binding.addIngredientButton.setOnClickListener {
+            TODO()
+        }
+    }
+}

--- a/app/src/main/java/com/example/kakelandet_mycookbook/AddIngredientViewModel.kt
+++ b/app/src/main/java/com/example/kakelandet_mycookbook/AddIngredientViewModel.kt
@@ -1,0 +1,7 @@
+package com.example.kakelandet_mycookbook
+
+import androidx.lifecycle.ViewModel
+
+class AddIngredientViewModel : ViewModel() {
+    // TODO: Implement the ViewModel
+}

--- a/app/src/main/java/com/example/kakelandet_mycookbook/IngredientsListFragment.kt
+++ b/app/src/main/java/com/example/kakelandet_mycookbook/IngredientsListFragment.kt
@@ -6,6 +6,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.example.kakelandet_mycookbook.databinding.FragmentIngredientsListBinding
 
@@ -25,6 +26,11 @@ class IngredientsListFragment : Fragment() {
 
         binding.ingredientsRv.adapter = IngredientListAdapter(viewModel.getIngredientList())
         binding.ingredientsRv.layoutManager = LinearLayoutManager(requireContext())
+        binding.addIngredientFab.setOnClickListener{
+            findNavController().navigate(
+                R.id.action_ingredientsListFragment_to_addIngredientFragment
+            )
+        }
 
         return binding.root
     }

--- a/app/src/main/res/layout/fragment_add_ingredient.xml
+++ b/app/src/main/res/layout/fragment_add_ingredient.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".AddIngredientFragment"
+    android:background="@color/kakelandet_yellow">
+
+
+    <TextView
+        android:id="@+id/addIngredientLabel"
+        style="@style/CardTitle"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginEnd="16dp"
+        android:layout_marginBottom="32dp"
+        android:text="@string/ingredient_name_label"
+        app:layout_constraintBottom_toTopOf="@+id/editTextIngredientName"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="1.0"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_chainStyle="packed" />
+
+    <EditText
+        android:id="@+id/editTextIngredientName"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginEnd="16dp"
+        android:layout_marginBottom="128dp"
+        android:inputType="textShortMessage"
+        android:hint="@string/new_ingredient_edit_text_hint"
+        app:layout_constraintBottom_toTopOf="@+id/addIngredientButton"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/addIngredientLabel"
+        />
+
+    <Button
+        android:id="@+id/addIngredientButton"
+        style="@style/RegularButton"
+        android:layout_width="200dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="32dp"
+        android:layout_marginEnd="32dp"
+        android:text="@string/add_button_text"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/editTextIngredientName" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_add_ingredient.xml
+++ b/app/src/main/res/layout/fragment_add_ingredient.xml
@@ -19,7 +19,6 @@
         android:text="@string/ingredient_name_label"
         app:layout_constraintBottom_toTopOf="@+id/editTextIngredientName"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="1.0"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintVertical_chainStyle="packed" />
@@ -35,7 +34,6 @@
         android:hint="@string/new_ingredient_edit_text_hint"
         app:layout_constraintBottom_toTopOf="@+id/addIngredientButton"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.0"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/addIngredientLabel"
         />

--- a/app/src/main/res/navigation/main_nav.xml
+++ b/app/src/main/res/navigation/main_nav.xml
@@ -39,10 +39,18 @@
         <action
             android:id="@+id/action_ingredientsListFragment2_to_ingredientDetailsFragment2"
             app:destination="@id/ingredientDetailsFragment" />
+        <action
+            android:id="@+id/action_ingredientsListFragment_to_addIngredientFragment"
+            app:destination="@id/addIngredientFragment" />
     </fragment>
     <fragment
         android:id="@+id/ingredientDetailsFragment"
         android:name="com.example.kakelandet_mycookbook.IngredientDetailsFragment"
         android:label="Ingredient"
         tools:layout="@layout/fragment_ingredient_details" />
+    <fragment
+        android:id="@+id/addIngredientFragment"
+        android:name="com.example.kakelandet_mycookbook.AddIngredientFragment"
+        android:label="Add New Ingredient"
+        tools:layout="@layout/fragment_add_ingredient" />
 </navigation>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,4 +11,7 @@
     <string name="nav_close">Close</string>
     <string name="recipe_imageView_description">A picture of the recipe</string>
     <string name="add_ingredient_button_description">Add Ingredient Button</string>
+    <string name="ingredient_name_label">Ingredient Name</string>
+    <string name="new_ingredient_edit_text_hint">New Ingredient </string>
+    <string name="add_button_text">Add</string>
 </resources>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #5 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Adds the files and UI elements for the Add Ingredient screen. It also adds the navigation from the FAB in the Ingredients List screen to the Add Ingredient screen. 

Please notice that the ADD button in the Add Ingredient screen does not currently do  anything, info is being stored anywhere yet


### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- Run the app
- CLick either on the Ingredients button in the home screen or from the Drawer Menu
- Click on the FAB + button 
- make sure it navigates to the Add Ingredient Screen 
- Rotate the screen, make sure it does not break 
- type something, and make sure the input text field works 

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

<img src="https://user-images.githubusercontent.com/30724184/209412363-9b931c1c-9cd4-4e51-8d23-2ae438609f0d.gif" width="350"/>


<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
